### PR TITLE
Version number

### DIFF
--- a/root/Gruntfile.js
+++ b/root/Gruntfile.js
@@ -17,16 +17,16 @@ module.exports = function( grunt ) {
         latedef: true,
         newcap:  true,
         noarg:   true,
-        sub:   true,
+        sub:     true,
         undef:   true,
-        boss:  true,
+        boss:    true,
         eqnull:  true,
-        devel:true,
+        devel:   true,
         globals: {
-          window:true,
+          window:  true,
           exports: true,
           module:  false,
-          jQuery: false,
+          jQuery:  false,
           Console: false
         }
       }

--- a/root/functions.php
+++ b/root/functions.php
@@ -92,18 +92,22 @@ add_action( 'widgets_init', '{%= prefix %}_widgets_init' );
  * Enqueue scripts and styles.
  */
 function {%= prefix %}_scripts() {
+
+	${%= prefix %}_theme_data = wp_get_theme();
+	${%= prefix %}_theme_ver  = ${%= prefix %}_theme_data->get( 'Version' );
+
 	wp_enqueue_style(
 		'{%= prefix %}-style',
-		get_stylesheet_directory_uri() . '/style.css',
+		get_stylesheet_uri(),
 		array(),
-		'{%= grunt.template.today("yyyymmdd") %}'
+		${%= prefix %}_theme_ver
 	);
 
 	wp_enqueue_script(
 		'{%= prefix %}-navigation',
 		get_template_directory_uri() . '/js/navigation.js',
 		array(),
-		'{%= grunt.template.today("yyyymmdd") %}',
+		'20120206',
 		true
 	);
 
@@ -111,7 +115,7 @@ function {%= prefix %}_scripts() {
 		'{%= prefix %}-skip-link-focus-fix',
 		get_template_directory_uri() . '/js/skip-link-focus-fix.js',
 		array(),
-		'{%= grunt.template.today("yyyymmdd") %}',
+		'20130115',
 		true
 	);
 
@@ -123,7 +127,7 @@ function {%= prefix %}_scripts() {
 		'{%= prefix %}-script',
 		get_stylesheet_directory_uri() . '/js/{%= file_name %}.min.js',
 		array('jquery'),
-		'{%= grunt.template.today("yyyymmdd") %}',
+		${%= prefix %}_theme_ver,
 		true
 	);
 }

--- a/root/style.css
+++ b/root/style.css
@@ -4,7 +4,7 @@ Theme URI: {%= homepage %}
 Author: {%= author_name %}
 Author URI: {%= author_url %}
 Description: {%= description %}
-Version: 1.0
+Version: 0.1.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: {%= prefix %}


### PR DESCRIPTION
- init時のstyle.cssのバージョンを0.1.0に
- grunt task 実行時にコンパイルされる、js、cssのバージョン番号はpackage.jsonのversionの値を参照する
- function.php で読み込むcss、jsのバージョン引数の調整。コンパイルされたjs、style.cssのバージョン引数はstyle.cssヘッダー行のバージョンを与える。

まとめると package.json の version 値を変更して grunt すれば、js、style.css、functions.phpの引数全てに反映されるようにしました
