### PR TITLE
grunt-contrib-compass bug fix.

### DIFF
--- a/template.js
+++ b/template.js
@@ -34,7 +34,7 @@ exports.template = function( grunt, init, done ) {
             'grunt': '~0.4.1',
             'grunt-contrib-jshint': '~0.10.0',
             'grunt-contrib-uglify': '~0.5.0',
-            'grunt-contrib-compass': '~0.7.2',
+            'grunt-contrib-compass': '~0.9.1',
             'grunt-contrib-cssmin': '~0.10.0',
             "grunt-contrib-watch": '~0.6.0'
         };


### PR DESCRIPTION
"grunt-contrib-compass": "~0.9.1";

see. https://github.com/gruntjs/grunt-contrib-compass/commit/13a164de2b6e8822c7fabe62238f2bb02cf1ef57
