### PR TITLE
Merge _s [63d8fcb]

### DIFF
--- a/root/Gruntfile.js
+++ b/root/Gruntfile.js
@@ -75,7 +75,6 @@ module.exports = function( grunt ) {
         'License: GNU General Public License v2 or later\n' +
         'License URI: http://www.gnu.org/licenses/gpl-2.0.html\n' +
         'Text Domain: {%= prefix %}\n' +
-        'Domain Path: /languages/\n' +
         'Tags:\n' +
         '\n' +
         'This theme, like WordPress, is licensed under the GPL.\n' +

--- a/root/inc/custom-header.php
+++ b/root/inc/custom-header.php
@@ -7,7 +7,7 @@
 
 	<?php if ( get_header_image() ) : ?>
 	<a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">
-		<img src="<?php header_image(); ?>" width="<?php echo get_custom_header()->width; ?>" height="<?php echo get_custom_header()->height; ?>" alt="">
+		<img src="<?php header_image(); ?>" width="<?php echo esc_attr( get_custom_header()->width ); ?>" height="<?php echo esc_attr( get_custom_header()->height ); ?>" alt="">
 	</a>
 	<?php endif; // End header image check. ?>
 
@@ -16,7 +16,7 @@
  */
 
 /**
- * Setup the WordPress core custom header feature.
+ * Set up the WordPress core custom header feature.
  *
  * @uses {%= prefix %}_header_style()
  * @uses {%= prefix %}_admin_header_style()

--- a/root/style.css
+++ b/root/style.css
@@ -8,7 +8,6 @@ Version: 0.1.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: {%= prefix %}
-Domain Path: /languages/
 Tags:
 
 This theme, like WordPress, is licensed under the GPL.


### PR DESCRIPTION
 Add escaping to custom header example. Make sure that proper attribute escaping is added into the example that's in the custom header include file. Since we're not including this in header.php, we should at least make sure that the example given is proper and passes WordPress Coding Standards checks. See #552 for context.
 Setup is a noun. Set up is a verb. "Setup the WordPress core custom header feature." is incorrect. "Set up the WordPress core custom header feature." is correct.
 Remove Domain Path from style.css

see. 
https://github.com/Automattic/_s/commit/e6fd8e99cfa791518862275f1077c22e0b26c131
https://github.com/Automattic/_s/commit/01f15acadd84f462b29f6aec6a016d123fa6c22e
https://github.com/Automattic/_s/commit/63d8fcb190c147130756a6ecfce3ae796f148caf
