### PR TITLE
Merge _s[cfda009] : Better WordPress title handling for WordPress 4.1+ with proper back compat.

### DIFF
--- a/root/functions.php
+++ b/root/functions.php
@@ -22,10 +22,10 @@ if ( ! function_exists( '{%= prefix %}_setup' ) ) :
  */
 function {%= prefix %}_setup() {
 
-	/**
-	 * Make theme available for translation
-	 * Translations can be filed in the /languages/ directory
-	 * If you're building a theme based on {%= title %}, use a find and replace
+	/*
+	 * Make theme available for translation.
+	 * Translations can be filed in the /languages/ directory.
+	 * If you're building a theme based on {%= prefix %}, use a find and replace
 	 * to change '{%= prefix %}' to the name of your theme in all the template files
 	 */
 	load_theme_textdomain( '{%= prefix %}', get_template_directory() . '/languages' );
@@ -35,6 +35,14 @@ function {%= prefix %}_setup() {
 
 	// Add default posts and comments RSS feed links to head.
 	add_theme_support( 'automatic-feed-links' );
+
+	/*
+	 * Let WordPress manage the document title.
+	 * By adding theme support, we declare that this theme does not use a
+	 * hard-coded <title> tag in the document head, and expect WordPress to
+	 * provide it for us.
+	 */
+	add_theme_support( 'title-tag' );
 
 	/*
 	 * Enable support for Post Thumbnails on posts and pages.

--- a/root/header.php
+++ b/root/header.php
@@ -11,7 +11,6 @@
 <head>
 <meta charset="<?php bloginfo( 'charset' ); ?>">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title><?php wp_title( '|', true, 'right' ); ?></title>
 <link rel="profile" href="http://gmpg.org/xfn/11">
 <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>">
 

--- a/root/inc/extras.php
+++ b/root/inc/extras.php
@@ -35,37 +35,52 @@ function {%= prefix %}_body_classes( $classes ) {
 }
 add_filter( 'body_class', '{%= prefix %}_body_classes' );
 
-/**
- * Filters wp_title to print a neat <title> tag based on what is being viewed.
- *
- * @param string $title Default title text for current view.
- * @param string $sep Optional separator.
- * @return string The filtered title.
- */
-function {%= prefix %}_wp_title( $title, $sep ) {
-	if ( is_feed() ) {
+if ( ! function_exists( '_wp_render_title_tag' ) ) :
+	/**
+	 * Filters wp_title to print a neat <title> tag based on what is being viewed.
+	 *
+	 * @param string $title Default title text for current view.
+	 * @param string $sep Optional separator.
+	 * @return string The filtered title.
+	 */
+	function {%= prefix %}_wp_title( $title, $sep ) {
+		if ( is_feed() ) {
+			return $title;
+		}
+
+		global $page, $paged;
+
+		// Add the blog name
+		$title .= get_bloginfo( 'name', 'display' );
+
+		// Add the blog description for the home/front page.
+		$site_description = get_bloginfo( 'description', 'display' );
+		if ( $site_description && ( is_home() || is_front_page() ) ) {
+			$title .= " $sep $site_description";
+		}
+
+		// Add a page number if necessary:
+		if ( ( $paged >= 2 || $page >= 2 ) && ! is_404() ) {
+			$title .= " $sep " . sprintf( __( 'Page %s', '{%= prefix %}' ), max( $paged, $page ) );
+		}
+
 		return $title;
 	}
+	add_filter( 'wp_title', '{%= prefix %}_wp_title', 10, 2 );
+endif;
 
-	global $page, $paged;
-
-	// Add the blog name
-	$title .= get_bloginfo( 'name', 'display' );
-
-	// Add the blog description for the home/front page.
-	$site_description = get_bloginfo( 'description', 'display' );
-	if ( $site_description && ( is_home() || is_front_page() ) ) {
-		$title .= " $sep $site_description";
+if ( ! function_exists( '_wp_render_title_tag' ) ) :
+	/**
+	 * Title shim for sites older than WordPress 4.1.
+	 *
+	 * @link https://make.wordpress.org/core/2014/10/29/title-tags-in-4-1/
+	 * @todo Remove this function when WordPress 4.3 is released.
+	 */
+	function {%= prefix %}_render_title() {
+		echo '<title>' . wp_title( '|', false, 'right' ) . "</title>\n";
 	}
-
-	// Add a page number if necessary:
-	if ( ( $paged >= 2 || $page >= 2 ) && ! is_404() ) {
-		$title .= " $sep " . sprintf( __( 'Page %s', '{%= prefix %}' ), max( $paged, $page ) );
-	}
-
-	return $title;
-}
-add_filter( 'wp_title', '{%= prefix %}_wp_title', 10, 2 );
+	add_action( 'wp_head', '{%= prefix %}_render_title' );
+endif;
 
 /**
  * Sets the authordata global when viewing an author archive.


### PR DESCRIPTION
Better WordPress title handling for WordPress 4.1+ with proper back compat.
see. https://github.com/Automattic/_s/commit/cfda0096b3700be474fad9011ae8056ec7ead723
- Adjust todo notice for wp_title shim.
- Better title handling for WordPress 4.1. See #644.
- First pass at better title handling for WordPress 4.1+ with proper back compatibility baked in.
