### PR TITLE
current_page_ancestor -> current-page-ancestor

### DIFF
--- a/root/sass/navigation/_menus.scss
+++ b/root/sass/navigation/_menus.scss
@@ -57,7 +57,7 @@
 
 	.current_page_item > a,
 	.current-menu-item > a,
-	.current_page_ancestor > a {
+	.current-page-ancestor > a {
 	}
 }
 


### PR DESCRIPTION
メニューのカレントクラス名が違ってたので修正しました。